### PR TITLE
Fix follower counts after actions

### DIFF
--- a/src/ui_main.py
+++ b/src/ui_main.py
@@ -532,6 +532,16 @@ class MainWindow(QMainWindow):
             f"Successfully unfollowed {unfollowed_count} users who are not following you.",
         )
 
+        # Refresh counts and clear the non-followers list
+        self.github_manager.clear_internal_cache()
+        following = self.github_manager.get_following()
+        followers = self.github_manager.get_followers()
+
+        self.non_follower_list.clear()
+        self.non_follower_label.setText("Non-followers: 0")
+        self.total_following_label.setText(f"Following: {len(following)}")
+        self.total_followers_label.setText(f"Followers: {len(followers)}")
+
     def clear_non_followers_list(self):
         self.non_follower_list.clear()
 
@@ -585,6 +595,15 @@ class MainWindow(QMainWindow):
             "Follow Back Success",
             f"Successfully followed back {followed_count} users.",
         )
+
+        # Refresh counts and clear the follow-back list
+        self.github_manager.clear_internal_cache()
+        following = self.github_manager.get_following()
+        followers = self.github_manager.get_followers()
+
+        self.to_follow_list.clear()
+        self.total_following_label.setText(f"Following: {len(following)}")
+        self.total_followers_label.setText(f"Followers: {len(followers)}")
 
         # Refresh the "to follow" list (optional)
         # self.update_follow_back_list()

--- a/tests/test_github_manager.py
+++ b/tests/test_github_manager.py
@@ -3,6 +3,10 @@ import types
 import unittest
 import tempfile
 import os
+from pathlib import Path
+
+# Ensure the src directory is on the path for imports
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 
 # Provide a minimal fake 'github' module to allow importing GitHubManager
 class FakeUser:
@@ -10,16 +14,28 @@ class FakeUser:
         self.login = login
         self._following = []
         self._followers = []
+        self.unfollowed = []
+        self.followed = []
+
     def get_following(self):
         return self._following
+
     def get_followers(self):
         return self._followers
+
     def remove_from_following(self, user):
-        pass
+        self.unfollowed.append(user.login)
+        if user in self._following:
+            self._following.remove(user)
+
     def add_to_following(self, user):
-        pass
+        self.followed.append(user.login)
+        if user not in self._following:
+            self._following.append(user)
+
     def get_starred(self):
         return []
+
     def remove_from_starred(self, repo):
         pass
 
@@ -32,12 +48,19 @@ class FakeUser:
 class FakeGithub:
     def __init__(self, token):
         self._user = FakeUser("me")
-    def get_user(self):
-        return self._user
+        self._users = {"me": self._user}
+
+    def get_user(self, login=None):
+        if login is None:
+            return self._user
+        # Return existing or create new fake user
+        if login not in self._users:
+            self._users[login] = FakeUser(login)
+        return self._users[login]
 
 sys.modules['github'] = types.SimpleNamespace(Github=FakeGithub)
 
-from src.github_api import GitHubManager
+from github_api import GitHubManager
 
 class GitHubManagerTest(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary
- update counts after unfollow and follow back operations
- keep tests working with local imports

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683c95a687e0832baef86a9c1db7ff56