### PR TITLE
Add CLI automation and GitHub Actions workflow

### DIFF
--- a/.github/workflows/automation.yml
+++ b/.github/workflows/automation.yml
@@ -1,0 +1,38 @@
+name: FollowEqualizer Automation
+
+on:
+  workflow_dispatch:
+    inputs:
+      follow_back:
+        description: 'Run follow back action'
+        required: false
+        default: 'true'
+      unfollow_nonfollowers:
+        description: 'Run unfollow nonfollowers action'
+        required: false
+        default: 'true'
+  schedule:
+    - cron: '0 9 * * *'
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Execute automation actions
+        env:
+          GITHUB_TOKEN: ${{ secrets.FOLLOW_EQUALIZER_TOKEN }}
+        run: |
+          args=""
+          if [ "${{ github.event.inputs.follow_back }}" != "false" ]; then
+            args="$args --follow-back"
+          fi
+          if [ "${{ github.event.inputs.unfollow_nonfollowers }}" != "false" ]; then
+            args="$args --unfollow-nonfollowers"
+          fi
+          python src/automation.py $args

--- a/README.md
+++ b/README.md
@@ -138,3 +138,25 @@ The tool leverages the GitHub API to retrieve and manage data. Some key function
 3. **Follow Back Non-Followed Followers**: Press this button to automatically follow back users who follow you but whom you are not following.
 4. **Find Repositories to Unstar**: Press the button to retrieve a list of starred repositories. You can then choose to unstar them.
 5. **Add to Exceptions**: Use this to add selected users or repositories to an exception list, preventing them from being unfollowed or unstarred.
+
+## Automation with CLI and GitHub Actions
+
+In addition to the GUI, you can automate follow management from the command line.
+The `src/automation.py` script exposes the same follow back and unfollow logic
+used in the desktop application. It reads your `GITHUB_TOKEN` from the `.env`
+file and accepts two optional flags:
+
+```bash
+python src/automation.py --follow-back --unfollow-nonfollowers
+```
+
+The script uses the `exclude_list.json` file to respect any users you have
+marked as exceptions.
+
+### Running in GitHub Actions
+
+A workflow is provided at `.github/workflows/automation.yml`. Configure a secret
+named `FOLLOW_EQUALIZER_TOKEN` in your repository settings and enable the
+workflow. It can be triggered manually from the Actions tab or automatically on a
+schedule (default runs daily at 09:00 UTC).
+

--- a/src/automation.py
+++ b/src/automation.py
@@ -1,0 +1,80 @@
+import argparse
+import os
+from pathlib import Path
+from dotenv import load_dotenv
+
+from github_api import GitHubManager
+
+
+def follow_back(github_manager: GitHubManager, exclude_list):
+    """Follow back users who follow you but whom you're not following."""
+    followers = github_manager.get_followers()
+    following = github_manager.get_following()
+
+    followers_set = {u.login for u in followers}
+    following_set = {u.login for u in following}
+
+    to_follow = [
+        login for login in followers_set - following_set if login not in exclude_list
+    ]
+
+    for login in to_follow:
+        user = github_manager.g.get_user(login)
+        github_manager.follow(user)
+
+    print(f"Followed back {len(to_follow)} user(s).")
+
+
+def unfollow_nonfollowers(github_manager: GitHubManager, exclude_list):
+    """Unfollow users you follow who do not follow you back."""
+    non_followers = github_manager.get_non_followers(exclude_list)
+    for user in non_followers:
+        github_manager.unfollow(user)
+    print(f"Unfollowed {len(non_followers)} user(s).")
+
+
+def load_excludes(path: str):
+    if not path:
+        return []
+    manager = GitHubManager("dummy")  # token not used for loading file
+    data = manager.load_exclude_list(path)
+    return data.get("users", [])
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Automate GitHub follow actions")
+    parser.add_argument(
+        "--follow-back",
+        action="store_true",
+        help="Follow back users who follow you",
+    )
+    parser.add_argument(
+        "--unfollow-nonfollowers",
+        action="store_true",
+        help="Unfollow users who don't follow you",
+    )
+    parser.add_argument(
+        "--exclude-file",
+        default="exclude_list.json",
+        help="Path to exclude list JSON file",
+    )
+    args = parser.parse_args()
+
+    load_dotenv(Path(__file__).resolve().parent.parent / ".env")
+    token = os.getenv("GITHUB_TOKEN")
+    if not token:
+        raise RuntimeError("GITHUB_TOKEN not set")
+
+    manager = GitHubManager(token)
+
+    exclude = load_excludes(args.exclude_file)
+
+    if args.follow_back:
+        follow_back(manager, exclude)
+
+    if args.unfollow_nonfollowers:
+        unfollow_nonfollowers(manager, exclude)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_automation.py
+++ b/tests/test_automation.py
@@ -1,0 +1,73 @@
+import sys
+import types
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+sys.modules['dotenv'] = types.SimpleNamespace(load_dotenv=lambda *a, **k: None)
+
+class FakeUser:
+    def __init__(self, login):
+        self.login = login
+        self._following = []
+        self._followers = []
+        self.followed = []
+        self.unfollowed = []
+
+    def get_following(self):
+        return self._following
+
+    def get_followers(self):
+        return self._followers
+
+    def add_to_following(self, user):
+        self.followed.append(user.login)
+        if user not in self._following:
+            self._following.append(user)
+
+    def remove_from_following(self, user):
+        self.unfollowed.append(user.login)
+        if user in self._following:
+            self._following.remove(user)
+
+    def __eq__(self, other):
+        return isinstance(other, FakeUser) and self.login == getattr(other, "login", None)
+
+    def __hash__(self):
+        return hash(self.login)
+
+class FakeGithub:
+    def __init__(self, token):
+        self._user = FakeUser("me")
+        self._users = {"me": self._user}
+
+    def get_user(self, login=None):
+        if login is None:
+            return self._user
+        if login not in self._users:
+            self._users[login] = FakeUser(login)
+        return self._users[login]
+
+sys.modules['github'] = types.SimpleNamespace(Github=FakeGithub)
+
+from github_api import GitHubManager
+from automation import follow_back, unfollow_nonfollowers
+
+class AutomationTest(unittest.TestCase):
+    def setUp(self):
+        self.manager = GitHubManager("token")
+        self.manager.user._followers = [FakeUser("a"), FakeUser("b")]
+        self.manager.user._following = [FakeUser("b"), FakeUser("c")]
+
+    def test_follow_back(self):
+        follow_back(self.manager, [])
+        self.assertIn("a", self.manager.user.followed)
+        self.assertNotIn("b", self.manager.user.followed)
+
+    def test_unfollow_nonfollowers(self):
+        unfollow_nonfollowers(self.manager, [])
+        self.assertIn("c", self.manager.user.unfollowed)
+        self.assertNotIn("b", self.manager.user.unfollowed)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a new command line script `automation.py` to automate follow/unfollow
- document how to use the script and workflow in README
- add a GitHub Actions workflow for scheduled/manual execution
- add unit tests for the automation helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683e788198bc832b83fe5321d0e3a49f